### PR TITLE
Make the jade dependency included in all dependencies (not just dev)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "expressjs",
     "compile"
   ],
+  "dependencies": {
+    "jade": "~0.34.1"
+  },
   "devDependencies": {
-    "mocha": ">=1.10.0",
-    "jade": ">=0.32.0"
+    "mocha": ">=1.10.0"
   },
   "author": "Dmitry Shirokov <deadrunk@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Shouldn't jade be included among all the dependencies and not just the development ones?
