### PR TITLE
Use end to send the response and end it

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function(opts) {
         if (err)
           return next(err);
 
-        return res.send(html);
+        return res.end(html);
       });
 
     });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Connect (expressjs) middleware for serving html files from jade template",
   "main": "index.js",
+  "engines": {
+    "node": ">=0.10.15"
+  },
   "scripts": {
     "test": "mocha -R spec --recursive"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ describe('connect-jade-static', function() {
     var mw = cjs({ baseUrl: '/views', baseDir: path.join(__dirname, 'views') });
 
     var req = { originalUrl: '/views/tpl.html' };
-    var res = { send: function(html) {
+    var res = { end: function(html) {
       // otherwise jade tries to catch this error :/
       process.nextTick(function() {
         assert.equal(html, '<h1>Hello</h1><ul><li>aaa</li><li>bbb</li><li>ccc</li></ul>');
@@ -38,7 +38,7 @@ describe('connect-jade-static', function() {
     var mw = cjs({ baseUrl: '/views', baseDir: path.join(__dirname, 'views'), jade: { pretty: true } });
 
     var req = { originalUrl: '/views/tpl.html' };
-    var res = { send: function(html) {
+    var res = { end: function(html) {
       // otherwise jade tries to catch this error :/
       process.nextTick(function() {
         assert.equal(html,
@@ -62,7 +62,7 @@ describe('connect-jade-static', function() {
     var mw = cjs({ baseUrl: '/views', baseDir: path.join(__dirname, 'views') });
 
     var req = { originalUrl: '/views/blah.html' };
-    var res = { send: function(html) {
+    var res = { end: function(html) {
       throw new Error('Code shouldn\'t reach here');
     }};
 
@@ -73,7 +73,7 @@ describe('connect-jade-static', function() {
     var mw = cjs({ baseUrl: '/views', baseDir: path.join(__dirname, 'views') });
 
     var req = { originalUrl: '/views/tpl_err.html' };
-    var res = { send: function(html) {
+    var res = { end: function(html) {
       throw new Error('Code shouldn\'t reach here');
     }};
     var next = function(err) {


### PR DESCRIPTION
I couldn't find exactly when the change occurred but some things have changed with the ServerResponse so you now need to both write a response and end it (or do it at the same time with the end() method). The send method doesn't exist anymore.
