### PR TITLE
only try to serve regular files

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(opts) {
     if (req.originalUrl.indexOf(opts.baseUrl) !== 0)
       return next();
 
-    var filepath = module.exports.getTplPath(req, opts)
+    var filepath = module.exports.getTplPath(req, opts);
 
     if (filepath.indexOf(opts.baseDir) !== 0)
       return next(new Error('Invalid path'));
@@ -28,15 +28,21 @@ module.exports = function(opts) {
       if (!exists)
         return next();
 
-      jade.renderFile(filepath, opts.jade, function renderFile(err, html) {
+      fs.stat(filepath, function(err, stats) {
         if (err)
           return next(err);
+        if (!stats.isFile())
+          return next();
 
-        res.setHeader('Content-Length', Buffer.byteLength(html));
-        res.setHeader('Content-Type', 'text/html; charset=utf-8');
-        return res.end(html);
+        jade.renderFile(filepath, opts.jade, function renderFile(err, html) {
+          if (err)
+            return next(err);
+
+          res.setHeader('Content-Length', Buffer.byteLength(html));
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          return res.end(html);
+        });
       });
-
     });
   };
 


### PR DESCRIPTION
I added a check if the requested file is actually a regular file. Without this check, connect-jade-static tried to serve requests for directory indices as well. This resulted in errors of the form:

```
Error: EISDIR, illegal operation on a directory
   at Object.fs.readSync (fs.js:476:19)
   at Object.fs.readFileSync (fs.js:310:28) 
   at Object.exports.renderFile (/home/adrian/....y/node_modules/jade/lib/jade.js:340:10)
   at Object.exports.renderFile (/home/adrian/...../node_modules/jade/lib/jade.js:326:21)
   at isExists (/home/adrian/Documents/..../node_modules/connect-jade-static/index.js:31:12)
   at Object.cb [as oncomplete] (fs.js:168:19) 
```
