### PR TITLE
Ignore irrelevant files

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function(opts) {
 
   opts.jade = opts.jade || {};
 
+  opts.ext = opts.ext || ['.jade'];
 
   return function(req, res, next) {
 
@@ -20,6 +21,10 @@ module.exports = function(opts) {
       return next();
 
     var filepath = module.exports.getTplPath(req, opts);
+
+    // Handle only .jade files
+    if (opts.ext.indexOf(path.extname(filepath)) === -1)
+      return next();
 
     if (filepath.indexOf(opts.baseDir) !== 0)
       return next(new Error('Invalid path'));

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,15 @@ describe('connect-jade-static', function() {
       mw(req, res, done);
     });
 
+    it('should ignore requests without an appropriate .jade file', function(done) {
+      var mw = cjs({ baseUrl: '/views', baseDir: path.join(__dirname, 'views') });
+      var req = { originalUrl: '/views/no_tpl.css' };
+      var res = { end: function(html) {
+        throw new Error('Code shouldn\'t reach here');
+      }};
+      mw(req, res, done);
+    });
+
     it('should raise error if jade template invalid', function(done) {
       var mw = cjs({ baseUrl: '/views', baseDir: path.join(__dirname, 'views') });
       var req = { originalUrl: '/views/tpl_err.html' };

--- a/test/views/no_tpl.css
+++ b/test/views/no_tpl.css
@@ -1,0 +1,1 @@
+.example { content: 'Hello World' }


### PR DESCRIPTION
Right now the jade middleware compiles any requested file.

In the following example the middleware would allow to request 'index.html', 'index.jade' and 'styles.css'.
Unfortunately it would compile the styles.css file to html.

```
  public
  |
  |--- index.jade
  |--- styles.css
```

This pull requests limits the file extension for templates to opts.ext which is set to '.jade' per default.
The way the middleware handles html files is not affected as the getTplPath method turns html urls into jade urls.