### PR TITLE
path check fix for windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function(opts) {
     if (!filepath)
       return next();
 
-    if (filepath.indexOf(opts.baseDir) !== 0)
+    if (path.relative(opts.baseDir, filepath)[0] === '.')
       return res.sendStatus(403);
 
     fs.stat(filepath, function(err, stats) {


### PR DESCRIPTION
getTplPath returns a platform-dependent path, but it is compared to opts.baseDir with indexOf, resulting 403 errors when otps,basedir contains '/' characters.
Using path.relative check and checking whether the relative path starts with '.' ('..' means filepath is outside of baseDir) solves the problem.
